### PR TITLE
Fix clippy error

### DIFF
--- a/lib/kerml/src/root/qualified_name.rs
+++ b/lib/kerml/src/root/qualified_name.rs
@@ -10,10 +10,6 @@ impl QualifiedName {
         Self(names)
     }
 
-    pub fn to_string(&self) -> String {
-        self.0.join("::")
-    }
-
     pub fn to_vec(&self) -> Vec<String> {
         self.0.clone()
     }
@@ -63,6 +59,14 @@ impl From<&str> for QualifiedName {
 
 impl fmt::Display for QualifiedName {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.to_string())
+        let mut iter = self.0.iter();
+        if let Some(s) = iter.next() {
+            f.write_str(s)?;
+        }
+        for s in iter {
+            f.write_str("::")?;
+            f.write_str(s)?;
+        }
+        Ok(())
     }
 }


### PR DESCRIPTION
This also has the advantage of preventing unrequired allocations in Display::fmt

### Clippy error

```
error: type `root::qualified_name::QualifiedName` implements inherent method `to_string(&self) -> String` which shadows the implementation of `Display`
  --> lib/kerml/src/root/qualified_name.rs:13:5
   |
13 | /     pub fn to_string(&self) -> String {
14 | |         self.0.join("::")
15 | |     }
   | |_____^
   |
   = help: remove the inherent method from type `root::qualified_name::QualifiedName`
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#inherent_to_string_shadow_display
   = note: `#[deny(clippy::inherent_to_string_shadow_display)]` on by default
```